### PR TITLE
New interface: YNAB::API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ require 'ynab'
 
 access_token = 'bf0cbb14b4330-not-real-3de12e66a389eaafe2'
 
-ynab = YnabApi::Client.new(access_token)
+ynab = YNAB::API.new(access_token)
 
 budget_response = ynab.budgets.get_budgets
 budgets = budget_response.data.budgets

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "gemName": "ynab",
-  "moduleName": "YnabApi",
+  "moduleName": "YNAB",
   "gemVersion": "1.0.0",
   "gemDescription": "Ruby gem wrapper for the YNAB API. Read the documentation at https://api.youneedabudget.com",
   "gemHomepage": "https://github.com/ynab/ynab-sdk-ruby",

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -1,4 +1,4 @@
-# YnabApi::Account
+# YNAB::Account
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/AccountResponse.md
+++ b/docs/AccountResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::AccountResponse
+# YNAB::AccountResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/AccountWrapper.md
+++ b/docs/AccountWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::AccountWrapper
+# YNAB::AccountWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/AccountsApi.md
+++ b/docs/AccountsApi.md
@@ -1,4 +1,4 @@
-# YnabApi::AccountsApi
+# YNAB::AccountsApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/AccountsResponse.md
+++ b/docs/AccountsResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::AccountsResponse
+# YNAB::AccountsResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/AccountsWrapper.md
+++ b/docs/AccountsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::AccountsWrapper
+# YNAB::AccountsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetDetail.md
+++ b/docs/BudgetDetail.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetDetail
+# YNAB::BudgetDetail
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetDetailResponse.md
+++ b/docs/BudgetDetailResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetDetailResponse
+# YNAB::BudgetDetailResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetDetailWrapper.md
+++ b/docs/BudgetDetailWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetDetailWrapper
+# YNAB::BudgetDetailWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetSettings.md
+++ b/docs/BudgetSettings.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetSettings
+# YNAB::BudgetSettings
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetSettingsResponse.md
+++ b/docs/BudgetSettingsResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetSettingsResponse
+# YNAB::BudgetSettingsResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetSettingsWrapper.md
+++ b/docs/BudgetSettingsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetSettingsWrapper
+# YNAB::BudgetSettingsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetSummary.md
+++ b/docs/BudgetSummary.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetSummary
+# YNAB::BudgetSummary
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetSummaryResponse.md
+++ b/docs/BudgetSummaryResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetSummaryResponse
+# YNAB::BudgetSummaryResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetSummaryWrapper.md
+++ b/docs/BudgetSummaryWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetSummaryWrapper
+# YNAB::BudgetSummaryWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BudgetsApi.md
+++ b/docs/BudgetsApi.md
@@ -1,4 +1,4 @@
-# YnabApi::BudgetsApi
+# YNAB::BudgetsApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/BulkIdWrapper.md
+++ b/docs/BulkIdWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::BulkIdWrapper
+# YNAB::BulkIdWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BulkIds.md
+++ b/docs/BulkIds.md
@@ -1,4 +1,4 @@
-# YnabApi::BulkIds
+# YNAB::BulkIds
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BulkResponse.md
+++ b/docs/BulkResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::BulkResponse
+# YNAB::BulkResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/BulkTransactionCreateResponse.md
+++ b/docs/BulkTransactionCreateResponse.md
@@ -1,8 +1,8 @@
-# YnabApi::BulkTransactionCreateResponse
+# YNAB::BulkTransactionCreateResponse
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**data** | [**BulkTransactionIds**](BulkTransactionIds.md) |  | 
+**data** | [**BulkTransactionIds**](BulkTransactionIds.md) |  |
 
 

--- a/docs/BulkTransactionIds.md
+++ b/docs/BulkTransactionIds.md
@@ -1,8 +1,8 @@
-# YnabApi::BulkTransactionIds
+# YNAB::BulkTransactionIds
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**transaction_ids** | **Array&lt;String&gt;** |  | 
+**transaction_ids** | **Array&lt;String&gt;** |  |
 
 

--- a/docs/BulkTransactions.md
+++ b/docs/BulkTransactions.md
@@ -1,4 +1,4 @@
-# YnabApi::BulkTransactions
+# YNAB::BulkTransactions
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CategoriesApi.md
+++ b/docs/CategoriesApi.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoriesApi
+# YNAB::CategoriesApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/CategoriesResponse.md
+++ b/docs/CategoriesResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoriesResponse
+# YNAB::CategoriesResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/Category.md
+++ b/docs/Category.md
@@ -1,4 +1,4 @@
-# YnabApi::Category
+# YNAB::Category
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CategoryGroup.md
+++ b/docs/CategoryGroup.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoryGroup
+# YNAB::CategoryGroup
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CategoryGroupWithCategories.md
+++ b/docs/CategoryGroupWithCategories.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoryGroupWithCategories
+# YNAB::CategoryGroupWithCategories
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CategoryGroupsWrapper.md
+++ b/docs/CategoryGroupsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoryGroupsWrapper
+# YNAB::CategoryGroupsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CategoryResponse.md
+++ b/docs/CategoryResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoryResponse
+# YNAB::CategoryResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CategoryWrapper.md
+++ b/docs/CategoryWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::CategoryWrapper
+# YNAB::CategoryWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/CurrencyFormat.md
+++ b/docs/CurrencyFormat.md
@@ -1,4 +1,4 @@
-# YnabApi::CurrencyFormat
+# YNAB::CurrencyFormat
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/DateFormat.md
+++ b/docs/DateFormat.md
@@ -1,4 +1,4 @@
-# YnabApi::DateFormat
+# YNAB::DateFormat
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ErrorDetail.md
+++ b/docs/ErrorDetail.md
@@ -1,4 +1,4 @@
-# YnabApi::ErrorDetail
+# YNAB::ErrorDetail
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ErrorResponse.md
+++ b/docs/ErrorResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::ErrorResponse
+# YNAB::ErrorResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/HybridTransaction.md
+++ b/docs/HybridTransaction.md
@@ -1,4 +1,4 @@
-# YnabApi::HybridTransaction
+# YNAB::HybridTransaction
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/HybridTransactionsResponse.md
+++ b/docs/HybridTransactionsResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::HybridTransactionsResponse
+# YNAB::HybridTransactionsResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/HybridTransactionsWrapper.md
+++ b/docs/HybridTransactionsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::HybridTransactionsWrapper
+# YNAB::HybridTransactionsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthDetail.md
+++ b/docs/MonthDetail.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthDetail
+# YNAB::MonthDetail
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthDetailResponse.md
+++ b/docs/MonthDetailResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthDetailResponse
+# YNAB::MonthDetailResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthDetailWrapper.md
+++ b/docs/MonthDetailWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthDetailWrapper
+# YNAB::MonthDetailWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthSummariesResponse.md
+++ b/docs/MonthSummariesResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthSummariesResponse
+# YNAB::MonthSummariesResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthSummariesWrapper.md
+++ b/docs/MonthSummariesWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthSummariesWrapper
+# YNAB::MonthSummariesWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthSummary.md
+++ b/docs/MonthSummary.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthSummary
+# YNAB::MonthSummary
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/MonthsApi.md
+++ b/docs/MonthsApi.md
@@ -1,4 +1,4 @@
-# YnabApi::MonthsApi
+# YNAB::MonthsApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/Payee.md
+++ b/docs/Payee.md
@@ -1,4 +1,4 @@
-# YnabApi::Payee
+# YNAB::Payee
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeLocation.md
+++ b/docs/PayeeLocation.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeLocation
+# YNAB::PayeeLocation
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeLocationResponse.md
+++ b/docs/PayeeLocationResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeLocationResponse
+# YNAB::PayeeLocationResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeLocationWrapper.md
+++ b/docs/PayeeLocationWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeLocationWrapper
+# YNAB::PayeeLocationWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeLocationsApi.md
+++ b/docs/PayeeLocationsApi.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeLocationsApi
+# YNAB::PayeeLocationsApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/PayeeLocationsResponse.md
+++ b/docs/PayeeLocationsResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeLocationsResponse
+# YNAB::PayeeLocationsResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeLocationsWrapper.md
+++ b/docs/PayeeLocationsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeLocationsWrapper
+# YNAB::PayeeLocationsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeResponse.md
+++ b/docs/PayeeResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeResponse
+# YNAB::PayeeResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeeWrapper.md
+++ b/docs/PayeeWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeeWrapper
+# YNAB::PayeeWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeesApi.md
+++ b/docs/PayeesApi.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeesApi
+# YNAB::PayeesApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/PayeesResponse.md
+++ b/docs/PayeesResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeesResponse
+# YNAB::PayeesResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/PayeesWrapper.md
+++ b/docs/PayeesWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::PayeesWrapper
+# YNAB::PayeesWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/SaveTransaction.md
+++ b/docs/SaveTransaction.md
@@ -1,4 +1,4 @@
-# YnabApi::SaveTransaction
+# YNAB::SaveTransaction
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/SaveTransactionWrapper.md
+++ b/docs/SaveTransactionWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::SaveTransactionWrapper
+# YNAB::SaveTransactionWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledSubTransaction.md
+++ b/docs/ScheduledSubTransaction.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledSubTransaction
+# YNAB::ScheduledSubTransaction
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledTransactionDetail.md
+++ b/docs/ScheduledTransactionDetail.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionDetail
+# YNAB::ScheduledTransactionDetail
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledTransactionResponse.md
+++ b/docs/ScheduledTransactionResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionResponse
+# YNAB::ScheduledTransactionResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledTransactionSummary.md
+++ b/docs/ScheduledTransactionSummary.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionSummary
+# YNAB::ScheduledTransactionSummary
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledTransactionWrapper.md
+++ b/docs/ScheduledTransactionWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionWrapper
+# YNAB::ScheduledTransactionWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledTransactionsApi.md
+++ b/docs/ScheduledTransactionsApi.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionsApi
+# YNAB::ScheduledTransactionsApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/ScheduledTransactionsResponse.md
+++ b/docs/ScheduledTransactionsResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionsResponse
+# YNAB::ScheduledTransactionsResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/ScheduledTransactionsWrapper.md
+++ b/docs/ScheduledTransactionsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::ScheduledTransactionsWrapper
+# YNAB::ScheduledTransactionsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/SubTransaction.md
+++ b/docs/SubTransaction.md
@@ -1,4 +1,4 @@
-# YnabApi::SubTransaction
+# YNAB::SubTransaction
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/TransactionDetail.md
+++ b/docs/TransactionDetail.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionDetail
+# YNAB::TransactionDetail
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/TransactionResponse.md
+++ b/docs/TransactionResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionResponse
+# YNAB::TransactionResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/TransactionSummary.md
+++ b/docs/TransactionSummary.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionSummary
+# YNAB::TransactionSummary
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/TransactionWrapper.md
+++ b/docs/TransactionWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionWrapper
+# YNAB::TransactionWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/TransactionsApi.md
+++ b/docs/TransactionsApi.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionsApi
+# YNAB::TransactionsApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/TransactionsResponse.md
+++ b/docs/TransactionsResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionsResponse
+# YNAB::TransactionsResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/TransactionsWrapper.md
+++ b/docs/TransactionsWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::TransactionsWrapper
+# YNAB::TransactionsWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/User.md
+++ b/docs/User.md
@@ -1,4 +1,4 @@
-# YnabApi::User
+# YNAB::User
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/UserApi.md
+++ b/docs/UserApi.md
@@ -1,4 +1,4 @@
-# YnabApi::UserApi
+# YNAB::UserApi
 
 All URIs are relative to *https://api.youneedabudget.com/v1*
 

--- a/docs/UserResponse.md
+++ b/docs/UserResponse.md
@@ -1,4 +1,4 @@
-# YnabApi::UserResponse
+# YNAB::UserResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/docs/UserWrapper.md
+++ b/docs/UserWrapper.md
@@ -1,4 +1,4 @@
-# YnabApi::UserWrapper
+# YNAB::UserWrapper
 
 ## Properties
 Name | Type | Description | Notes

--- a/examples/budget-list.rb
+++ b/examples/budget-list.rb
@@ -3,7 +3,7 @@ require 'ynab'
 
 def print_budget_list
   access_token = 'bf0cbb14b4330-not-real-3de12e66a389eaafe2'
-  ynab = YnabApi::Client.new(access_token)
+  ynab = YNAB::API.new(access_token)
 
   puts "Fetching budgets..."
   begin

--- a/examples/budget-month.rb
+++ b/examples/budget-month.rb
@@ -4,7 +4,7 @@ require 'date'
 
 def print_budget_month
   access_token = 'bf0cbb14b4330-not-real-3de12e66a389eaafe2'
-  ynab = YnabApi::Client.new(access_token)
+  ynab = YNAB::API.new(access_token)
 
   budget_id = "f968197b-2863-not-real-c2406dbe7f0d"
   first_day_of_month_iso = Date.new(Date.today.year, Date.today.month, 1).iso8601

--- a/examples/category-balance.rb
+++ b/examples/category-balance.rb
@@ -3,7 +3,7 @@ require 'ynab'
 
 def print_category_info
   access_token = 'bf0cbb14b4330-not-real-3de12e66a389eaafe2'
-  ynab = YnabApi::Client.new(access_token)
+  ynab = YNAB::API.new(access_token)
 
   budget_id = "f968197b-2863-not-real-c2406dbe7f0d"
   category_id = "a191ac84-de09-not-real-6c5ed8cfdabe"

--- a/lib/ynab.rb
+++ b/lib/ynab.rb
@@ -96,8 +96,8 @@ require 'ynab/api/scheduled_transactions_api'
 require 'ynab/api/transactions_api'
 require 'ynab/api/user_api'
 
-module YnabApi
-  class Client
+module YNAB
+  class API
     def initialize(access_token, host = 'api.youneedabudget.com', useHttps = true)
       config = Configuration.default
       config.api_key['Authorization'] = access_token
@@ -148,5 +148,11 @@ module YnabApi
     def last_request
       @client.last_request
     end
+  end
+end
+
+# Support old interface: YnabApi::Client
+module YnabApi
+  class Client < YNAB::API
   end
 end

--- a/lib/ynab/api/accounts_api.rb
+++ b/lib/ynab/api/accounts_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class AccountsApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/budgets_api.rb
+++ b/lib/ynab/api/budgets_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class BudgetsApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/categories_api.rb
+++ b/lib/ynab/api/categories_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class CategoriesApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/months_api.rb
+++ b/lib/ynab/api/months_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class MonthsApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/payee_locations_api.rb
+++ b/lib/ynab/api/payee_locations_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class PayeeLocationsApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/payees_api.rb
+++ b/lib/ynab/api/payees_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class PayeesApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/scheduled_transactions_api.rb
+++ b/lib/ynab/api/scheduled_transactions_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionsApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/transactions_api.rb
+++ b/lib/ynab/api/transactions_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class TransactionsApi
     attr_accessor :api_client
 

--- a/lib/ynab/api/user_api.rb
+++ b/lib/ynab/api/user_api.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class UserApi
     attr_accessor :api_client
 

--- a/lib/ynab/api_client.rb
+++ b/lib/ynab/api_client.rb
@@ -17,7 +17,7 @@ require 'tempfile'
 require 'typhoeus'
 require 'uri'
 
-module YnabApi
+module YNAB
   class ApiClient
     # The Configuration object holding settings to be used in the API client.
     attr_accessor :config
@@ -213,7 +213,7 @@ module YnabApi
         end
       else
         # models, e.g. Pet
-        YnabApi.const_get(return_type).new.tap do |model|
+        YNAB.const_get(return_type).new.tap do |model|
           model.build_from_hash data
         end
       end

--- a/lib/ynab/api_error.rb
+++ b/lib/ynab/api_error.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 =end
 
-module YnabApi
+module YNAB
   class ApiError < StandardError
     attr_reader :code, :response_headers, :response_body
 

--- a/lib/ynab/configuration.rb
+++ b/lib/ynab/configuration.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'uri'
 
-module YnabApi
+module YNAB
   class Configuration
     # Defines url scheme
     attr_accessor :scheme

--- a/lib/ynab/models/account.rb
+++ b/lib/ynab/models/account.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class Account
     attr_accessor :id
 
@@ -305,7 +305,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/account_response.rb
+++ b/lib/ynab/models/account_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class AccountResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/account_wrapper.rb
+++ b/lib/ynab/models/account_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class AccountWrapper
     attr_accessor :account
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/accounts_response.rb
+++ b/lib/ynab/models/accounts_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class AccountsResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/accounts_wrapper.rb
+++ b/lib/ynab/models/accounts_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class AccountsWrapper
     attr_accessor :accounts
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_detail.rb
+++ b/lib/ynab/models/budget_detail.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetDetail
     attr_accessor :id
 
@@ -290,7 +290,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_detail_response.rb
+++ b/lib/ynab/models/budget_detail_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetDetailResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_detail_wrapper.rb
+++ b/lib/ynab/models/budget_detail_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetDetailWrapper
     attr_accessor :budget
 
@@ -153,7 +153,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_settings.rb
+++ b/lib/ynab/models/budget_settings.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetSettings
     attr_accessor :date_format
 
@@ -152,7 +152,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_settings_response.rb
+++ b/lib/ynab/models/budget_settings_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetSettingsResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_settings_wrapper.rb
+++ b/lib/ynab/models/budget_settings_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetSettingsWrapper
     attr_accessor :settings
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_summary.rb
+++ b/lib/ynab/models/budget_summary.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetSummary
     attr_accessor :id
 
@@ -180,7 +180,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_summary_response.rb
+++ b/lib/ynab/models/budget_summary_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetSummaryResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/budget_summary_wrapper.rb
+++ b/lib/ynab/models/budget_summary_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BudgetSummaryWrapper
     attr_accessor :budgets
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/bulk_id_wrapper.rb
+++ b/lib/ynab/models/bulk_id_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BulkIdWrapper
     attr_accessor :bulk
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/bulk_ids.rb
+++ b/lib/ynab/models/bulk_ids.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BulkIds
     # The list of Transaction IDs that were created.
     attr_accessor :transaction_ids
@@ -158,7 +158,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/bulk_response.rb
+++ b/lib/ynab/models/bulk_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BulkResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/bulk_transaction_create_response.rb
+++ b/lib/ynab/models/bulk_transaction_create_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.3.1
 
 require 'date'
 
-module YnabApi
+module YNAB
 
   class BulkTransactionCreateResponse
     attr_accessor :data
@@ -141,7 +141,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/bulk_transaction_ids.rb
+++ b/lib/ynab/models/bulk_transaction_ids.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.3.1
 
 require 'date'
 
-module YnabApi
+module YNAB
 
   class BulkTransactionIds
     attr_accessor :transaction_ids
@@ -143,7 +143,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/bulk_transactions.rb
+++ b/lib/ynab/models/bulk_transactions.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class BulkTransactions
     attr_accessor :transactions
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/categories_response.rb
+++ b/lib/ynab/models/categories_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CategoriesResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/category.rb
+++ b/lib/ynab/models/category.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class Category
     attr_accessor :id
 
@@ -265,7 +265,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/category_group.rb
+++ b/lib/ynab/models/category_group.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CategoryGroup
     attr_accessor :id
 
@@ -182,7 +182,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/category_group_with_categories.rb
+++ b/lib/ynab/models/category_group_with_categories.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CategoryGroupWithCategories
     attr_accessor :id
 
@@ -199,7 +199,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/category_groups_wrapper.rb
+++ b/lib/ynab/models/category_groups_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CategoryGroupsWrapper
     attr_accessor :category_groups
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/category_response.rb
+++ b/lib/ynab/models/category_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CategoryResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/category_wrapper.rb
+++ b/lib/ynab/models/category_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CategoryWrapper
     attr_accessor :category
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/currency_format.rb
+++ b/lib/ynab/models/currency_format.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class CurrencyFormat
     attr_accessor :iso_code
 
@@ -236,7 +236,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/date_format.rb
+++ b/lib/ynab/models/date_format.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class DateFormat
     attr_accessor :format
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/error_detail.rb
+++ b/lib/ynab/models/error_detail.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ErrorDetail
     attr_accessor :id
 
@@ -166,7 +166,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/error_response.rb
+++ b/lib/ynab/models/error_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ErrorResponse
     attr_accessor :error
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/hybrid_transaction.rb
+++ b/lib/ynab/models/hybrid_transaction.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class HybridTransaction
     attr_accessor :id
 
@@ -442,7 +442,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/hybrid_transactions_response.rb
+++ b/lib/ynab/models/hybrid_transactions_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class HybridTransactionsResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/hybrid_transactions_wrapper.rb
+++ b/lib/ynab/models/hybrid_transactions_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class HybridTransactionsWrapper
     attr_accessor :transactions
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/month_detail.rb
+++ b/lib/ynab/models/month_detail.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class MonthDetail
     attr_accessor :month
 
@@ -198,7 +198,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/month_detail_response.rb
+++ b/lib/ynab/models/month_detail_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class MonthDetailResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/month_detail_wrapper.rb
+++ b/lib/ynab/models/month_detail_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class MonthDetailWrapper
     attr_accessor :month
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/month_summaries_response.rb
+++ b/lib/ynab/models/month_summaries_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class MonthSummariesResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/month_summaries_wrapper.rb
+++ b/lib/ynab/models/month_summaries_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class MonthSummariesWrapper
     attr_accessor :months
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/month_summary.rb
+++ b/lib/ynab/models/month_summary.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class MonthSummary
     attr_accessor :month
 
@@ -181,7 +181,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee.rb
+++ b/lib/ynab/models/payee.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class Payee
     attr_accessor :id
 
@@ -182,7 +182,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_location.rb
+++ b/lib/ynab/models/payee_location.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeLocation
     attr_accessor :id
 
@@ -195,7 +195,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_location_response.rb
+++ b/lib/ynab/models/payee_location_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeLocationResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_location_wrapper.rb
+++ b/lib/ynab/models/payee_location_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeLocationWrapper
     attr_accessor :payee_location
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_locations_response.rb
+++ b/lib/ynab/models/payee_locations_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeLocationsResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_locations_wrapper.rb
+++ b/lib/ynab/models/payee_locations_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeLocationsWrapper
     attr_accessor :payee_locations
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_response.rb
+++ b/lib/ynab/models/payee_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payee_wrapper.rb
+++ b/lib/ynab/models/payee_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeeWrapper
     attr_accessor :payee
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payees_response.rb
+++ b/lib/ynab/models/payees_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeesResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/payees_wrapper.rb
+++ b/lib/ynab/models/payees_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class PayeesWrapper
     attr_accessor :payees
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/save_transaction.rb
+++ b/lib/ynab/models/save_transaction.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class SaveTransaction
     attr_accessor :account_id
 
@@ -292,7 +292,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/save_transaction_wrapper.rb
+++ b/lib/ynab/models/save_transaction_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class SaveTransactionWrapper
     attr_accessor :transaction
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_sub_transaction.rb
+++ b/lib/ynab/models/scheduled_sub_transaction.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledSubTransaction
     attr_accessor :id
 
@@ -239,7 +239,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_transaction_detail.rb
+++ b/lib/ynab/models/scheduled_transaction_detail.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionDetail
     attr_accessor :id
 
@@ -403,7 +403,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_transaction_response.rb
+++ b/lib/ynab/models/scheduled_transaction_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_transaction_summary.rb
+++ b/lib/ynab/models/scheduled_transaction_summary.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionSummary
     attr_accessor :id
 
@@ -344,7 +344,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_transaction_wrapper.rb
+++ b/lib/ynab/models/scheduled_transaction_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionWrapper
     attr_accessor :scheduled_transaction
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_transactions_response.rb
+++ b/lib/ynab/models/scheduled_transactions_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionsResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/scheduled_transactions_wrapper.rb
+++ b/lib/ynab/models/scheduled_transactions_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class ScheduledTransactionsWrapper
     attr_accessor :scheduled_transactions
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/sub_transaction.rb
+++ b/lib/ynab/models/sub_transaction.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class SubTransaction
     attr_accessor :id
 
@@ -239,7 +239,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/transaction_detail.rb
+++ b/lib/ynab/models/transaction_detail.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class TransactionDetail
     attr_accessor :id
 
@@ -417,7 +417,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/transaction_response.rb
+++ b/lib/ynab/models/transaction_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class TransactionResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/transaction_summary.rb
+++ b/lib/ynab/models/transaction_summary.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class TransactionSummary
     attr_accessor :id
 
@@ -358,7 +358,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/transaction_wrapper.rb
+++ b/lib/ynab/models/transaction_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class TransactionWrapper
     attr_accessor :transaction
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/transactions_response.rb
+++ b/lib/ynab/models/transactions_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class TransactionsResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/transactions_wrapper.rb
+++ b/lib/ynab/models/transactions_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class TransactionsWrapper
     attr_accessor :transactions
 
@@ -140,7 +140,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/user.rb
+++ b/lib/ynab/models/user.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class User
     attr_accessor :id
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/user_response.rb
+++ b/lib/ynab/models/user_response.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class UserResponse
     attr_accessor :data
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/models/user_wrapper.rb
+++ b/lib/ynab/models/user_wrapper.rb
@@ -12,7 +12,7 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 require 'date'
 
-module YnabApi
+module YNAB
   class UserWrapper
     attr_accessor :user
 
@@ -138,7 +138,7 @@ module YnabApi
           end
         end
       else # model
-        temp_model = YnabApi.const_get(type).new
+        temp_model = YNAB.const_get(type).new
         temp_model.build_from_hash(value)
       end
     end

--- a/lib/ynab/version.rb
+++ b/lib/ynab/version.rb
@@ -10,6 +10,6 @@ Swagger Codegen version: 2.4.0-SNAPSHOT
 
 =end
 
-module YnabApi
+module YNAB
   VERSION = '1.0.0'
 end

--- a/spec/api/accounts_spec.rb
+++ b/spec/api/accounts_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'accounts' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.accounts }
 
   describe 'test an instance of AccountsApi' do
     it 'should create an instance of AccountsApi' do
-      expect(instance).to be_instance_of(YnabApi::AccountsApi)
+      expect(instance).to be_instance_of(YNAB::AccountsApi)
     end
   end
 
@@ -23,10 +23,10 @@ describe 'accounts' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("accounts_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.accounts.get_accounts(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end
@@ -51,6 +51,15 @@ describe 'accounts' do
         expect(response.data.account).to be
         expect(response.data.account.name).to eq "Checking"
       end
+    end
+  end
+
+  it "foobar" do
+    VCR.use_cassette("accounts") do
+      client = YnabApi::Client.new(access_token, 'api.localhost:3000', false)
+      response = client.accounts.get_accounts(budget_id)
+      expect(client.last_request.response.options[:code]).to be 200
+      expect(response.data.accounts.length).to be 1
     end
   end
 end

--- a/spec/api/budgets_spec.rb
+++ b/spec/api/budgets_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe 'budgets' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.budgets }
 
   describe 'test an instance of BudgetsApi' do
     it 'should create an instance of BudgetsApi' do
-      expect(instance).to be_instance_of(YnabApi::BudgetsApi)
+      expect(instance).to be_instance_of(YNAB::BudgetsApi)
     end
   end
 
@@ -22,10 +22,10 @@ describe 'budgets' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("budgets_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.budgets.get_budgets
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/spec/api/categories_spec.rb
+++ b/spec/api/categories_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'categories' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.categories }
 
   describe 'test an instance of CategoriesApi' do
     it 'should create an instance of CategoriesApi' do
-      expect(instance).to be_instance_of(YnabApi::CategoriesApi)
+      expect(instance).to be_instance_of(YNAB::CategoriesApi)
     end
   end
 
@@ -23,10 +23,10 @@ describe 'categories' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("categories_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.categories.get_categories(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/spec/api/months_spec.rb
+++ b/spec/api/months_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'months' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.months }
 
   describe 'test an instance of MonthsApi' do
     it 'should create an instance of MonthsApi' do
-      expect(instance).to be_instance_of(YnabApi::MonthsApi)
+      expect(instance).to be_instance_of(YNAB::MonthsApi)
     end
   end
 
@@ -23,10 +23,10 @@ describe 'months' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("months_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.months.get_budget_months(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/spec/api/payee_locations_spec.rb
+++ b/spec/api/payee_locations_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'payee locations' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.payee_locations }
 
   describe 'test an instance of PayeeLocationsApi' do
     it 'should create an instance of PayeeLocationsApi' do
-      expect(instance).to be_instance_of(YnabApi::PayeeLocationsApi)
+      expect(instance).to be_instance_of(YNAB::PayeeLocationsApi)
     end
   end
 
@@ -23,10 +23,10 @@ describe 'payee locations' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("payee_locations_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.payee_locations.get_payee_locations(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/spec/api/payees_spec.rb
+++ b/spec/api/payees_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'payees' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.payees }
 
   describe 'test an instance of PayeesApi' do
     it 'should create an instance of PayeesApi' do
-      expect(instance).to be_instance_of(YnabApi::PayeesApi)
+      expect(instance).to be_instance_of(YNAB::PayeesApi)
     end
   end
 
@@ -23,10 +23,10 @@ describe 'payees' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("payees_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.payees.get_payees(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/spec/api/scheduled_transactions_spec.rb
+++ b/spec/api/scheduled_transactions_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'scheduled transactions' do
   let(:access_token) { '9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045' }
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.scheduled_transactions }
 
   describe 'test an instance of ScheduledTransactionsApi' do
     it 'should create an instance of ScheduledTransactionApi' do
-      expect(instance).to be_instance_of(YnabApi::ScheduledTransactionsApi)
+      expect(instance).to be_instance_of(YNAB::ScheduledTransactionsApi)
     end
   end
 
@@ -23,10 +23,10 @@ describe 'scheduled transactions' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("scheduled_transactions_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.scheduled_transactions.get_scheduled_transactions(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/spec/api/transactions_spec.rb
+++ b/spec/api/transactions_spec.rb
@@ -6,12 +6,12 @@ describe 'transactions' do
   let(:budget_id) { 'f419ac25-6217-4175-88dc-c3136ff5f6fd' }
   let(:category_id) { '84ffe61c-081c-44db-ad23-6ee809206c40' }
   let(:payee_id) { '2676f959-c5de-4db2-8d3f-2503777b25fb' }
-  let(:client) { YnabApi::Client.new(access_token, 'api.localhost:3000', false) }
+  let(:client) { YNAB::API.new(access_token, 'api.localhost:3000', false) }
   let (:instance) { client.transactions }
 
   describe 'test an instance of TransactionsApi' do
     it 'should create an instance of TransactionApi' do
-      expect(instance).to be_instance_of(YnabApi::TransactionsApi)
+      expect(instance).to be_instance_of(YNAB::TransactionsApi)
     end
   end
 
@@ -26,10 +26,10 @@ describe 'transactions' do
 
     it "throws when unauthorized" do
       VCR.use_cassette("transactions_unauthorized") do
-        client = YnabApi::Client.new('not_valid_access_token', 'api.localhost:3000', false)
+        client = YNAB::API.new('not_valid_access_token', 'api.localhost:3000', false)
         begin
           response = client.transactions.get_transactions(budget_id)
-        rescue YnabApi::ApiError => e
+        rescue YNAB::ApiError => e
           expect(e.code).to be 401
           expect(client.last_request.response.options[:code]).to be 401
         end

--- a/swagger-templates/gem.mustache
+++ b/swagger-templates/gem.mustache
@@ -22,7 +22,7 @@ require '{{importPath}}'
 {{/apiInfo}}
 
 module {{moduleName}}
-  class Client
+  class API
     def initialize(access_token, host = 'api.youneedabudget.com', useHttps = true)
       config = Configuration.default
       config.api_key['Authorization'] = access_token
@@ -73,5 +73,11 @@ module {{moduleName}}
     def last_request
       @client.last_request
     end
+  end
+end
+
+# Support old interface: YnabApi::Client
+module YnabApi
+  class Client < {{moduleName}}::API
   end
 end

--- a/ynab.gemspec
+++ b/ynab.gemspec
@@ -17,7 +17,7 @@ require 'ynab/version'
 
 Gem::Specification.new do |s|
   s.name        = 'ynab'
-  s.version     = YnabApi::VERSION
+  s.version     = YNAB::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['You Need A Budget, LLC']
   s.email       = ['help@youneedabudget.com']


### PR DESCRIPTION
New interface that is consistent with the [JavaScript client](https://github.com/ynab/ynab-sdk-js) and is a little easier on the eyes:

Old:

```
ynab = YnabApi::Client.new(access_token)
```

New:
```
ynab = YNAB::API.new(access_token)
```