### PR TITLE
Implement support for goals

### DIFF
--- a/docs/Account.md
+++ b/docs/Account.md
@@ -9,9 +9,9 @@ Name | Type | Description | Notes
 **on_budget** | **BOOLEAN** | Whether this account is on budget or not | 
 **closed** | **BOOLEAN** | Whether this account is closed or not | 
 **note** | **String** |  | 
-**balance** | **Float** | The current balance of the account in milliunits format | 
-**cleared_balance** | **Float** | The current cleared balance of the account in milliunits format | 
-**uncleared_balance** | **Float** | The current uncleared balance of the account in milliunits format | 
+**balance** | **Integer** | The current balance of the account in milliunits format | 
+**cleared_balance** | **Integer** | The current cleared balance of the account in milliunits format | 
+**uncleared_balance** | **Integer** | The current uncleared balance of the account in milliunits format | 
 **deleted** | **BOOLEAN** | Whether or not the account has been deleted.  Deleted accounts will only be included in delta requests. | 
 
 

--- a/docs/BudgetDetailWrapper.md
+++ b/docs/BudgetDetailWrapper.md
@@ -4,6 +4,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **budget** | [**BudgetDetail**](BudgetDetail.md) |  | 
-**server_knowledge** | **Float** | The knowledge of the server | 
+**server_knowledge** | **Integer** | The knowledge of the server | 
 
 

--- a/docs/BudgetsApi.md
+++ b/docs/BudgetsApi.md
@@ -21,7 +21,7 @@ Returns a single budget with all related entities.  This resource is effectively
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **budget_id** | [**String**](.md)| The ID of the Budget. | 
- **last_knowledge_of_server** | **Float**| The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included. | [optional] 
+ **last_knowledge_of_server** | **Integer**| The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included. | [optional] 
 
 ### Return type
 

--- a/docs/Category.md
+++ b/docs/Category.md
@@ -9,9 +9,14 @@ Name | Type | Description | Notes
 **hidden** | **BOOLEAN** | Whether or not the category is hidden | 
 **original_category_group_id** | **String** | If category is hidden this is the id of the category group it originally belonged to before it was hidden. | [optional] 
 **note** | **String** |  | 
-**budgeted** | **Float** | Budgeted amount in current month in milliunits format | 
-**activity** | **Float** | Activity amount in current month in milliunits format | 
-**balance** | **Float** | Balance in current month in milliunits format | 
+**budgeted** | **Integer** | Budgeted amount in current month in milliunits format | 
+**activity** | **Integer** | Activity amount in current month in milliunits format | 
+**balance** | **Integer** | Balance in current month in milliunits format | 
+**goal_type** | **String** | The type of goal, if the cagegory has a goal (TB&#x3D;Target Category Balance, TBD&#x3D;Target Category Balance by Date, MF&#x3D;Monthly Funding) | 
+**goal_creation_month** | **Date** | The month a goal was created | 
+**goal_target** | **Integer** | The goal target amount in milliunits | 
+**goal_target_month** | **Date** | If the goal type is &#39;TBD&#39; (Target Category Balance by Date), this is the target month for the goal to be completed | 
+**goal_percentage_complete** | **Integer** | The percentage completion of the goal | 
 **deleted** | **BOOLEAN** | Whether or not the category has been deleted.  Deleted categories will only be included in delta requests. | 
 
 

--- a/docs/CurrencyFormat.md
+++ b/docs/CurrencyFormat.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **iso_code** | **String** |  | 
 **example_format** | **String** |  | 
-**decimal_digits** | **Float** |  | 
+**decimal_digits** | **Integer** |  | 
 **decimal_separator** | **String** |  | 
 **symbol_first** | **BOOLEAN** |  | 
 **group_separator** | **String** |  | 

--- a/docs/HybridTransaction.md
+++ b/docs/HybridTransaction.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** |  | 
 **date** | **Date** |  | 
-**amount** | **Float** | The transaction amount in milliunits format | 
+**amount** | **Integer** | The transaction amount in milliunits format | 
 **memo** | **String** |  | 
 **cleared** | **String** | The cleared status of the transaction | 
 **approved** | **BOOLEAN** | Whether or not the transaction is approved | 

--- a/docs/MonthDetail.md
+++ b/docs/MonthDetail.md
@@ -5,8 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **month** | **Date** |  | 
 **note** | **String** |  | 
-**to_be_budgeted** | **Float** | The current balance of the account in milliunits format | 
-**age_of_money** | **Float** |  | 
+**to_be_budgeted** | **Integer** | The current balance of the account in milliunits format | 
+**age_of_money** | **Integer** |  | 
 **categories** | [**Array&lt;Category&gt;**](Category.md) | The budget month categories | 
 
 

--- a/docs/MonthSummary.md
+++ b/docs/MonthSummary.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **month** | **Date** |  | 
 **note** | **String** |  | 
-**to_be_budgeted** | **Float** | The current balance of the account in milliunits format | 
-**age_of_money** | **Float** |  | 
+**to_be_budgeted** | **Integer** | The current balance of the account in milliunits format | 
+**age_of_money** | **Integer** |  | 
 
 

--- a/docs/ScheduledSubTransaction.md
+++ b/docs/ScheduledSubTransaction.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** |  | 
 **scheduled_transaction_id** | **String** |  | 
-**amount** | **Float** | The scheduled subtransaction amount in milliunits format | 
+**amount** | **Integer** | The scheduled subtransaction amount in milliunits format | 
 **memo** | **String** |  | 
 **payee_id** | **String** |  | 
 **category_id** | **String** |  | 

--- a/docs/ScheduledTransactionDetail.md
+++ b/docs/ScheduledTransactionDetail.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **date_first** | **Date** | The first date for which the Scheduled Transaction was scheduled. | 
 **date_next** | **Date** | The next date for which the Scheduled Transaction is scheduled. | 
 **frequency** | **String** |  | 
-**amount** | **Float** | The scheduled transaction amount in milliunits format | 
+**amount** | **Integer** | The scheduled transaction amount in milliunits format | 
 **memo** | **String** |  | 
 **flag_color** | **String** | The scheduled transaction flag | 
 **account_id** | **String** |  | 

--- a/docs/ScheduledTransactionSummary.md
+++ b/docs/ScheduledTransactionSummary.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **date_first** | **Date** | The first date for which the Scheduled Transaction was scheduled. | 
 **date_next** | **Date** | The next date for which the Scheduled Transaction is scheduled. | 
 **frequency** | **String** |  | 
-**amount** | **Float** | The scheduled transaction amount in milliunits format | 
+**amount** | **Integer** | The scheduled transaction amount in milliunits format | 
 **memo** | **String** |  | 
 **flag_color** | **String** | The scheduled transaction flag | 
 **account_id** | **String** |  | 

--- a/docs/SubTransaction.md
+++ b/docs/SubTransaction.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** |  | 
 **transaction_id** | **String** |  | 
-**amount** | **Float** | The subtransaction amount in milliunits format | 
+**amount** | **Integer** | The subtransaction amount in milliunits format | 
 **memo** | **String** |  | 
 **payee_id** | **String** |  | 
 **category_id** | **String** |  | 

--- a/docs/TransactionDetail.md
+++ b/docs/TransactionDetail.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** |  | 
 **date** | **Date** |  | 
-**amount** | **Float** | The transaction amount in milliunits format | 
+**amount** | **Integer** | The transaction amount in milliunits format | 
 **memo** | **String** |  | 
 **cleared** | **String** | The cleared status of the transaction | 
 **approved** | **BOOLEAN** | Whether or not the transaction is approved | 

--- a/docs/TransactionSummary.md
+++ b/docs/TransactionSummary.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** |  | 
 **date** | **Date** |  | 
-**amount** | **Float** | The transaction amount in milliunits format | 
+**amount** | **Integer** | The transaction amount in milliunits format | 
 **memo** | **String** |  | 
 **cleared** | **String** | The cleared status of the transaction | 
 **approved** | **BOOLEAN** | Whether or not the transaction is approved | 

--- a/lib/ynab/api/budgets_api.rb
+++ b/lib/ynab/api/budgets_api.rb
@@ -23,7 +23,7 @@ module YNAB
     # Returns a single budget with all related entities.  This resource is effectively a full budget export.
     # @param budget_id The ID of the Budget.
     # @param [Hash] opts the optional parameters
-    # @option opts [Float] :last_knowledge_of_server The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included.
+    # @option opts [Integer] :last_knowledge_of_server The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included.
     # @return [BudgetDetailResponse]
     def get_budget_by_id(budget_id, opts = {})
       data, _status_code, _headers = get_budget_by_id_with_http_info(budget_id, opts)
@@ -34,7 +34,7 @@ module YNAB
     # Returns a single budget with all related entities.  This resource is effectively a full budget export.
     # @param budget_id The ID of the Budget.
     # @param [Hash] opts the optional parameters
-    # @option opts [Float] :last_knowledge_of_server The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included.
+    # @option opts [Integer] :last_knowledge_of_server The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included.
     # @return [Array<(BudgetDetailResponse, Fixnum, Hash)>] BudgetDetailResponse data, response status code and response headers
     def get_budget_by_id_with_http_info(budget_id, opts = {})
       if @api_client.config.debugging

--- a/lib/ynab/models/account.rb
+++ b/lib/ynab/models/account.rb
@@ -88,9 +88,9 @@ module YNAB
         :'on_budget' => :'BOOLEAN',
         :'closed' => :'BOOLEAN',
         :'note' => :'String',
-        :'balance' => :'Float',
-        :'cleared_balance' => :'Float',
-        :'uncleared_balance' => :'Float',
+        :'balance' => :'Integer',
+        :'cleared_balance' => :'Integer',
+        :'uncleared_balance' => :'Integer',
         :'deleted' => :'BOOLEAN'
       }
     end

--- a/lib/ynab/models/budget_detail_wrapper.rb
+++ b/lib/ynab/models/budget_detail_wrapper.rb
@@ -31,7 +31,7 @@ module YNAB
     def self.swagger_types
       {
         :'budget' => :'BudgetDetail',
-        :'server_knowledge' => :'Float'
+        :'server_knowledge' => :'Integer'
       }
     end
 

--- a/lib/ynab/models/category.rb
+++ b/lib/ynab/models/category.rb
@@ -37,8 +37,45 @@ module YNAB
     # Balance in current month in milliunits format
     attr_accessor :balance
 
+    # The type of goal, if the cagegory has a goal (TB=Target Category Balance, TBD=Target Category Balance by Date, MF=Monthly Funding)
+    attr_accessor :goal_type
+
+    # The month a goal was created
+    attr_accessor :goal_creation_month
+
+    # The goal target amount in milliunits
+    attr_accessor :goal_target
+
+    # If the goal type is 'TBD' (Target Category Balance by Date), this is the target month for the goal to be completed
+    attr_accessor :goal_target_month
+
+    # The percentage completion of the goal
+    attr_accessor :goal_percentage_complete
+
     # Whether or not the category has been deleted.  Deleted categories will only be included in delta requests.
     attr_accessor :deleted
+
+    class EnumAttributeValidator
+      attr_reader :datatype
+      attr_reader :allowable_values
+
+      def initialize(datatype, allowable_values)
+        @allowable_values = allowable_values.map do |value|
+          case datatype.to_s
+          when /Integer/i
+            value.to_i
+          when /Float/i
+            value.to_f
+          else
+            value
+          end
+        end
+      end
+
+      def valid?(value)
+        !value || allowable_values.include?(value)
+      end
+    end
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
@@ -52,6 +89,11 @@ module YNAB
         :'budgeted' => :'budgeted',
         :'activity' => :'activity',
         :'balance' => :'balance',
+        :'goal_type' => :'goal_type',
+        :'goal_creation_month' => :'goal_creation_month',
+        :'goal_target' => :'goal_target',
+        :'goal_target_month' => :'goal_target_month',
+        :'goal_percentage_complete' => :'goal_percentage_complete',
         :'deleted' => :'deleted'
       }
     end
@@ -65,9 +107,14 @@ module YNAB
         :'hidden' => :'BOOLEAN',
         :'original_category_group_id' => :'String',
         :'note' => :'String',
-        :'budgeted' => :'Float',
-        :'activity' => :'Float',
-        :'balance' => :'Float',
+        :'budgeted' => :'Integer',
+        :'activity' => :'Integer',
+        :'balance' => :'Integer',
+        :'goal_type' => :'String',
+        :'goal_creation_month' => :'Date',
+        :'goal_target' => :'Integer',
+        :'goal_target_month' => :'Date',
+        :'goal_percentage_complete' => :'Integer',
         :'deleted' => :'BOOLEAN'
       }
     end
@@ -116,6 +163,26 @@ module YNAB
         self.balance = attributes[:'balance']
       end
 
+      if attributes.has_key?(:'goal_type')
+        self.goal_type = attributes[:'goal_type']
+      end
+
+      if attributes.has_key?(:'goal_creation_month')
+        self.goal_creation_month = attributes[:'goal_creation_month']
+      end
+
+      if attributes.has_key?(:'goal_target')
+        self.goal_target = attributes[:'goal_target']
+      end
+
+      if attributes.has_key?(:'goal_target_month')
+        self.goal_target_month = attributes[:'goal_target_month']
+      end
+
+      if attributes.has_key?(:'goal_percentage_complete')
+        self.goal_percentage_complete = attributes[:'goal_percentage_complete']
+      end
+
       if attributes.has_key?(:'deleted')
         self.deleted = attributes[:'deleted']
       end
@@ -157,6 +224,26 @@ module YNAB
         invalid_properties.push('invalid value for "balance", balance cannot be nil.')
       end
 
+      if @goal_type.nil?
+        invalid_properties.push('invalid value for "goal_type", goal_type cannot be nil.')
+      end
+
+      if @goal_creation_month.nil?
+        invalid_properties.push('invalid value for "goal_creation_month", goal_creation_month cannot be nil.')
+      end
+
+      if @goal_target.nil?
+        invalid_properties.push('invalid value for "goal_target", goal_target cannot be nil.')
+      end
+
+      if @goal_target_month.nil?
+        invalid_properties.push('invalid value for "goal_target_month", goal_target_month cannot be nil.')
+      end
+
+      if @goal_percentage_complete.nil?
+        invalid_properties.push('invalid value for "goal_percentage_complete", goal_percentage_complete cannot be nil.')
+      end
+
       if @deleted.nil?
         invalid_properties.push('invalid value for "deleted", deleted cannot be nil.')
       end
@@ -175,8 +262,25 @@ module YNAB
       return false if @budgeted.nil?
       return false if @activity.nil?
       return false if @balance.nil?
+      return false if @goal_type.nil?
+      goal_type_validator = EnumAttributeValidator.new('String', ['TB', 'TBD', 'MF'])
+      return false unless goal_type_validator.valid?(@goal_type)
+      return false if @goal_creation_month.nil?
+      return false if @goal_target.nil?
+      return false if @goal_target_month.nil?
+      return false if @goal_percentage_complete.nil?
       return false if @deleted.nil?
       true
+    end
+
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] goal_type Object to be assigned
+    def goal_type=(goal_type)
+      validator = EnumAttributeValidator.new('String', ['TB', 'TBD', 'MF'])
+      unless validator.valid?(goal_type)
+        fail ArgumentError, 'invalid value for "goal_type", must be one of #{validator.allowable_values}.'
+      end
+      @goal_type = goal_type
     end
 
     # Checks equality by comparing each attribute.
@@ -193,6 +297,11 @@ module YNAB
           budgeted == o.budgeted &&
           activity == o.activity &&
           balance == o.balance &&
+          goal_type == o.goal_type &&
+          goal_creation_month == o.goal_creation_month &&
+          goal_target == o.goal_target &&
+          goal_target_month == o.goal_target_month &&
+          goal_percentage_complete == o.goal_percentage_complete &&
           deleted == o.deleted
     end
 
@@ -205,7 +314,7 @@ module YNAB
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [id, category_group_id, name, hidden, original_category_group_id, note, budgeted, activity, balance, deleted].hash
+      [id, category_group_id, name, hidden, original_category_group_id, note, budgeted, activity, balance, goal_type, goal_creation_month, goal_target, goal_target_month, goal_percentage_complete, deleted].hash
     end
 
     # Builds the object from hash

--- a/lib/ynab/models/currency_format.rb
+++ b/lib/ynab/models/currency_format.rb
@@ -49,7 +49,7 @@ module YNAB
       {
         :'iso_code' => :'String',
         :'example_format' => :'String',
-        :'decimal_digits' => :'Float',
+        :'decimal_digits' => :'Integer',
         :'decimal_separator' => :'String',
         :'symbol_first' => :'BOOLEAN',
         :'group_separator' => :'String',

--- a/lib/ynab/models/hybrid_transaction.rb
+++ b/lib/ynab/models/hybrid_transaction.rb
@@ -109,7 +109,7 @@ module YNAB
       {
         :'id' => :'String',
         :'date' => :'Date',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'cleared' => :'String',
         :'approved' => :'BOOLEAN',

--- a/lib/ynab/models/month_detail.rb
+++ b/lib/ynab/models/month_detail.rb
@@ -42,8 +42,8 @@ module YNAB
       {
         :'month' => :'Date',
         :'note' => :'String',
-        :'to_be_budgeted' => :'Float',
-        :'age_of_money' => :'Float',
+        :'to_be_budgeted' => :'Integer',
+        :'age_of_money' => :'Integer',
         :'categories' => :'Array<Category>'
       }
     end

--- a/lib/ynab/models/month_summary.rb
+++ b/lib/ynab/models/month_summary.rb
@@ -38,8 +38,8 @@ module YNAB
       {
         :'month' => :'Date',
         :'note' => :'String',
-        :'to_be_budgeted' => :'Float',
-        :'age_of_money' => :'Float'
+        :'to_be_budgeted' => :'Integer',
+        :'age_of_money' => :'Integer'
       }
     end
 

--- a/lib/ynab/models/save_transaction.rb
+++ b/lib/ynab/models/save_transaction.rb
@@ -88,7 +88,7 @@ module YNAB
       {
         :'account_id' => :'String',
         :'date' => :'Date',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'payee_id' => :'String',
         :'payee_name' => :'String',
         :'category_id' => :'String',

--- a/lib/ynab/models/scheduled_sub_transaction.rb
+++ b/lib/ynab/models/scheduled_sub_transaction.rb
@@ -52,7 +52,7 @@ module YNAB
       {
         :'id' => :'String',
         :'scheduled_transaction_id' => :'String',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'payee_id' => :'String',
         :'category_id' => :'String',

--- a/lib/ynab/models/scheduled_transaction_detail.rb
+++ b/lib/ynab/models/scheduled_transaction_detail.rb
@@ -104,7 +104,7 @@ module YNAB
         :'date_first' => :'Date',
         :'date_next' => :'Date',
         :'frequency' => :'String',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'flag_color' => :'String',
         :'account_id' => :'String',

--- a/lib/ynab/models/scheduled_transaction_summary.rb
+++ b/lib/ynab/models/scheduled_transaction_summary.rb
@@ -91,7 +91,7 @@ module YNAB
         :'date_first' => :'Date',
         :'date_next' => :'Date',
         :'frequency' => :'String',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'flag_color' => :'String',
         :'account_id' => :'String',

--- a/lib/ynab/models/sub_transaction.rb
+++ b/lib/ynab/models/sub_transaction.rb
@@ -52,7 +52,7 @@ module YNAB
       {
         :'id' => :'String',
         :'transaction_id' => :'String',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'payee_id' => :'String',
         :'category_id' => :'String',

--- a/lib/ynab/models/transaction_detail.rb
+++ b/lib/ynab/models/transaction_detail.rb
@@ -105,7 +105,7 @@ module YNAB
       {
         :'id' => :'String',
         :'date' => :'Date',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'cleared' => :'String',
         :'approved' => :'BOOLEAN',

--- a/lib/ynab/models/transaction_summary.rb
+++ b/lib/ynab/models/transaction_summary.rb
@@ -92,7 +92,7 @@ module YNAB
       {
         :'id' => :'String',
         :'date' => :'Date',
-        :'amount' => :'Float',
+        :'amount' => :'Integer',
         :'memo' => :'String',
         :'cleared' => :'String',
         :'approved' => :'BOOLEAN',

--- a/spec-v1-swagger.json
+++ b/spec-v1-swagger.json
@@ -129,7 +129,7 @@
             "description":
               "The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included.",
             "required": false,
-            "type": "number"
+            "type": "integer"
           }
         ],
         "responses": {
@@ -1273,7 +1273,7 @@
           "type": "string"
         },
         "decimal_digits": {
-          "type": "number"
+          "type": "integer"
         },
         "decimal_separator": {
           "type": "string"
@@ -1330,7 +1330,7 @@
           "$ref": "#/definitions/BudgetDetail"
         },
         "server_knowledge": {
-          "type": "number",
+          "type": "integer",
           "description": "The knowledge of the server"
         }
       }
@@ -1552,19 +1552,19 @@
           "type": "string"
         },
         "balance": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description":
             "The current balance of the account in milliunits format"
         },
         "cleared_balance": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description":
             "The current cleared balance of the account in milliunits format"
         },
         "uncleared_balance": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description":
             "The current uncleared balance of the account in milliunits format"
@@ -1666,6 +1666,11 @@
         "budgeted",
         "activity",
         "balance",
+        "goal_type",
+        "goal_creation_month",
+        "goal_target",
+        "goal_target_month",
+        "goal_percentage_complete",
         "deleted"
       ],
       "properties": {
@@ -1693,16 +1698,39 @@
           "type": "string"
         },
         "budgeted": {
-          "type": "number",
+          "type": "integer",
           "description": "Budgeted amount in current month in milliunits format"
         },
         "activity": {
-          "type": "number",
+          "type": "integer",
           "description": "Activity amount in current month in milliunits format"
         },
         "balance": {
-          "type": "number",
+          "type": "integer",
           "description": "Balance in current month in milliunits format"
+        },
+        "goal_type": {
+          "type": "string",
+          "enum": ["TB", "TBD", "MF", null],
+          "description": "The type of goal, if the cagegory has a goal (TB=Target Category Balance, TBD=Target Category Balance by Date, MF=Monthly Funding)"
+        },
+        "goal_creation_month": {
+          "type": "string",
+          "format": "date",
+          "description": "The month a goal was created"
+        },
+        "goal_target": {
+          "type": "integer",
+          "description": "The goal target amount in milliunits"
+        },
+        "goal_target_month": {
+          "type": "string",
+          "format": "date",
+          "description": "If the goal type is 'TBD' (Target Category Balance by Date), this is the target month for the goal to be completed"
+        },
+        "goal_percentage_complete": {
+          "type": "integer",
+          "description": "The percentage completion of the goal"
         },
         "deleted": {
           "type": "boolean",
@@ -1921,7 +1949,7 @@
           "format": "date"
         },
         "amount": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description": "The transaction amount in milliunits format"
         },
@@ -2065,7 +2093,7 @@
           "format": "date"
         },
         "amount": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description": "The transaction amount in milliunits format"
         },
@@ -2184,7 +2212,7 @@
           "format": "uuid"
         },
         "amount": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description": "The subtransaction amount in milliunits format"
         },
@@ -2302,7 +2330,7 @@
           ]
         },
         "amount": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description": "The scheduled transaction amount in milliunits format"
         },
@@ -2395,7 +2423,7 @@
           "format": "uuid"
         },
         "amount": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description":
             "The scheduled subtransaction amount in milliunits format"
@@ -2474,13 +2502,13 @@
           "type": "string"
         },
         "to_be_budgeted": {
-          "type": "number",
+          "type": "integer",
           "format": "1234000",
           "description":
             "The current balance of the account in milliunits format"
         },
         "age_of_money": {
-          "type": "number"
+          "type": "integer"
         }
       }
     },


### PR DESCRIPTION
- Implement support for goals
- Update datatypes to use integers rather than floats for amounts, per a Swagger spec.  (Nothing has changed in the API responses; just the spec has been _corrected_)