### PR TITLE
Use action to hide sensitive inputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Hide the inputs values to keep them private in the logs when running this workflow
+        uses: levibostian/action-hide-sensitive-inputs@v1
       - uses: actions/checkout@v4
       - name: Setup git repo
         run: |
@@ -39,7 +41,7 @@ jobs:
       - name: Bump Version
         id: bump_version
         run: |
-          NEW_VERSION=$(rake "bump_version_number[${{ github.event.inputs.version_type }}]")
+          NEW_VERSION=$(rake "bump_version_number[${{ inputs.version_type }}]")
           echo "NEW_VERSION=$NEW_VERSION"
           echo "new_version=$(echo $NEW_VERSION)" >> $GITHUB_OUTPUT
       - name: Configure authentication to RubyGems
@@ -49,11 +51,11 @@ jobs:
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
         env:
-          GEM_HOST_API_KEY: "${{ github.event.inputs.rubygems_api_key }}"
+          GEM_HOST_API_KEY: "${{ inputs.rubygems_api_key }}"
       - name: Publish to RubyGems
         run: rake publish
         env:
-          GEM_HOST_OTP_CODE: ${{ github.event.inputs.rubygems_otp }}
+          GEM_HOST_OTP_CODE: ${{ inputs.rubygems_otp }}
       - name: Create a Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
For some reason, the `workflow_dispatch` action is somewhat of a second-class citizen, and does not receive a lot of the "safe by default" behavior that other action types do.

For example, there's not clear or obvious way to keep inputs secret & masked from the logs. GitHub's `add-mask` functionality doesn't work because the echo statement required to create the mask logs the value [(see this demo repo run)](https://github.com/joshmenden/workflow-dispatch-secret-demo/actions/runs/9304351236/job/25608705941).

If these inputs were automatically injected as environment variables like the documentation [suggest](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs) it does with `$INPUT_`, we wouldn't have to worry about the values being logged, but as of right now, `workflow_dispatch` actions [do not receive that behavior](https://github.com/orgs/community/discussions/25924).

The common workaround seems to be to parse out the inputs from the `GITHUB_EVENT` JSON and put those into an env var which then doesn't get logged. Something like:

```yml
jobs:
  test-secret:
    runs-on: ubuntu-latest
    steps:
    - name: Create secret environment variables from inputs 
      run: |
        SUPER_SECRET=$(jq -r '.inputs.super_secret' $GITHUB_EVENT_PATH)
        echo ::add-mask::$SUPER_SECRET
        echo SUPER_SECRET="$SUPER_SECRET" >> $GITHUB_ENV
    - name: Now, I can safely use input via environment variable
      run: echo "$SUPER_SECRET" # the output from this command will be "echo ***"
```

This is suggested a few times [here](https://github.com/actions/runner/issues/643#issuecomment-708228940), [here](https://stackoverflow.com/questions/67608874/how-to-mask-workflow-dispatch-inputs-like-secrets) and [here](https://dev.to/leading-edje/masking-input-parameters-in-github-actions-1ci).

Instead, I stumbled on this [GitHub Community Action](https://github.com/levibostian/action-hide-sensitive-inputs) which goes a step further and uses a node script to access GitHub action's core's [`setSecret` method](https://github.com/actions/toolkit/tree/main/packages/core#setting-a-secret). This felt like a less hacky way to go about protecting the sensitive information. You can see the results of using it in this [demo repo](https://github.com/joshmenden/workflow-dispatch-secret-demo/actions/runs/9304713391/job/25609960235).