### PR TITLE
Gracefully handle invalid transaction flag values from server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ynab (3.3.0)
+    ynab (3.4.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ynab (3.4.0)
+    ynab (3.5.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/config.json
+++ b/config.json
@@ -1,9 +1,0 @@
-{
-  "gemName": "ynab",
-  "moduleName": "YNAB",
-  "gemDescription": "Ruby gem wrapper for the YNAB API. Read the documentation at https://api.ynab.com",
-  "gemHomepage": "https://github.com/ynab/ynab-sdk-ruby",
-  "gemLicense": "Apache-2.0",
-  "gemAuthor": "YNAB",
-  "gemAuthorEmail": "api@ynab.com"
-}

--- a/lib/ynab/models/account_type.rb
+++ b/lib/ynab/models/account_type.rb
@@ -41,8 +41,12 @@ module YNAB
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      return value if AccountType.all_vars.include?(value)
-      raise "Invalid ENUM value #{value} for class #AccountType"
+      if AccountType.all_vars.include?(value)
+        return value
+      else
+        return nil
+      end
     end
   end
+
 end

--- a/lib/ynab/models/scheduled_transaction_frequency.rb
+++ b/lib/ynab/models/scheduled_transaction_frequency.rb
@@ -41,8 +41,12 @@ module YNAB
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      return value if ScheduledTransactionFrequency.all_vars.include?(value)
-      raise "Invalid ENUM value #{value} for class #ScheduledTransactionFrequency"
+      if ScheduledTransactionFrequency.all_vars.include?(value)
+        return value
+      else
+        return nil
+      end
     end
   end
+
 end

--- a/lib/ynab/models/transaction_cleared_status.rb
+++ b/lib/ynab/models/transaction_cleared_status.rb
@@ -31,8 +31,12 @@ module YNAB
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      return value if TransactionClearedStatus.all_vars.include?(value)
-      raise "Invalid ENUM value #{value} for class #TransactionClearedStatus"
+      if TransactionClearedStatus.all_vars.include?(value)
+        return value
+      else
+        return nil
+      end
     end
   end
+
 end

--- a/lib/ynab/models/transaction_flag_color.rb
+++ b/lib/ynab/models/transaction_flag_color.rb
@@ -35,8 +35,12 @@ module YNAB
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      return value if TransactionFlagColor.all_vars.include?(value)
-      raise "Invalid ENUM value #{value} for class #TransactionFlagColor"
+      if TransactionFlagColor.all_vars.include?(value)
+        return value
+      else
+        return nil
+      end
     end
   end
+
 end

--- a/spec/api/transactions_spec.rb
+++ b/spec/api/transactions_spec.rb
@@ -44,6 +44,18 @@ describe 'transactions' do
         expect(response.data.transactions.length).to be 2
       end
     end
+
+    it 'gracefully handles invalid flag_color values' do
+      # transactions_invalid_flags contains transactions with invalid/unsupported flag_color values
+      VCR.use_cassette("transactions_invalid_flags") do
+        response = instance.get_transactions(budget_id)
+        expect(client.last_request.response.options[:code]).to be 200
+        expect(response.data.transactions.length).to be 2
+        # We expect the flag_color to have been converted to nil for these transactions
+        expect(response.data.transactions[0].flag_color).to be_nil
+        expect(response.data.transactions[1].flag_color).to be_nil
+      end
+    end
   end
 
   describe 'GET /budgets/{budget_id}/category/{category_id}/transactions' do

--- a/spec/fixtures/vcr_cassettes/transactions_invalid_flags.yml
+++ b/spec/fixtures/vcr_cassettes/transactions_invalid_flags.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.localhost:3000/v1/budgets/f419ac25-6217-4175-88dc-c3136ff5f6fd/transactions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - api_client/ruby/0.1.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 9f1a2c4842b614a771aaae9220fc54ae835e298c4654dc2c9205fc1d7bd1a045
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding, Origin
+      ETag:
+      - W/"faa32c94f0e94eebee572fe3def08d83"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d290c58c-2261-4564-a267-5ea1ec878fdf
+      X-Runtime:
+      - '0.197369'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":{"transactions":[{"id":"1f9d45f6-8ba5-476b-8cff-209b3791bd83","date":"2018-02-15","amount":1000000,"memo":null,"cleared":"cleared","approved":true,"flag_color":"","account_id":"5982e895-98e5-41ca-9681-0b6de1036a1c","payee_id":"2141b5d8-5b9b-4a17-be45-3f4a9ac397ec","category_id":"26513650-523e-4e7a-ac0d-f6e78d0a8a03","transfer_account_id":null,"import_id":null,"subtransactions":[]},{"id":"81c374ff-74ab-4d6d-8d5a-ba3ad3fa68e4","date":"2018-02-15","amount":-2000,"memo":"","cleared":"uncleared","approved":true,"flag_color":"invalid","account_id":"5982e895-98e5-41ca-9681-0b6de1036a1c","payee_id":"200e6eb1-02fc-4af6-be26-27c5740bb949","category_id":null,"transfer_account_id":null,"import_id":null,"subtransactions":[]}]}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://api.localhost:3000/v1/budgets/f419ac25-6217-4175-88dc-c3136ff5f6fd/transactions
+  recorded_at: Thu, 15 Feb 2018 19:00:01 GMT
+recorded_with: VCR 3.0.3

--- a/templates/partial_model_enum_class.mustache
+++ b/templates/partial_model_enum_class.mustache
@@ -1,0 +1,26 @@
+  class {{classname}}{{#allowableValues}}{{#enumVars}}
+    {{{name}}} = {{{value}}}.freeze{{/enumVars}}
+
+{{/allowableValues}}
+    def self.all_vars
+      @all_vars ||= [{{#allowableValues}}{{#enumVars}}{{{name}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}].freeze
+    end
+
+    # Builds the enum from string
+    # @param [String] The enum value in the form of the string
+    # @return [String] The enum value
+    def self.build_from_hash(value)
+      new.build_from_hash(value)
+    end
+
+    # Builds the enum from string
+    # @param [String] The enum value in the form of the string
+    # @return [String] The enum value
+    def build_from_hash(value)
+      if {{classname}}.all_vars.include?(value)
+        return value
+      else
+        return nil
+      end
+    end
+  end

--- a/ynab.gemspec
+++ b/ynab.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.email       = ["api@ynab.com"]
   s.homepage    = "https://github.com/ynab/ynab-sdk-ruby"
   s.summary     = "YNAB API Client for Ruby"
-  s.description = "Ruby gem wrapper for the YNAB API. Generated from server specification version 1.72.0 using OpenAPI Generator version 7.7.0."
+  s.description = "Ruby gem wrapper for the YNAB API. API documentation available at https://api.ynab.com. Generated from server specification version 1.72.0 using OpenAPI Generator version 7.7.0."
   s.license     = "Apache-2.0"
   s.required_ruby_version = ">= 3.3"
   s.metadata    = {}


### PR DESCRIPTION
The OpenAPI Generator, by default, throws an error if enum type data is received from the server that is not defined in the spec.  In theory, the spec should always match what the server returns but in some cases there are unexpected values (new enum values not introduced in client, old enum values no longer in use, etc., bugs).

To work around this, we'll gracefully handle unsupported values by converting them to `nil` in the client, rather than throwing an error.

Fixes #81 