### PR TITLE
Use RubyGems trusted publishing in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,18 +10,15 @@ on:
         - major
         - minor
         - patch
-      rubygems_api_key:
-          description: API Key
-          required: true
-      rubygems_otp:
-        description: OTP Code
-        required: true
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
     steps:
-      - name: Hide the inputs values to keep them private in the logs when running this workflow
-        uses: levibostian/action-hide-sensitive-inputs@80877460a95aa5e56cba23314096ef0e0a3c10c1 # 1.1.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_API_TOKEN }}
@@ -47,18 +44,10 @@ jobs:
           NEW_VERSION=$(rake "bump_version_number[${{ inputs.version_type }}]")
           echo "NEW_VERSION=$NEW_VERSION"
           echo "new_version=$(echo $NEW_VERSION)" >> $GITHUB_OUTPUT
-      - name: Configure authentication to RubyGems
-        run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        env:
-          GEM_HOST_API_KEY: "${{ inputs.rubygems_api_key }}"
+      - name: Configure authentication to RubyGems (trusted publishing)
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
       - name: Publish to RubyGems
         run: rake publish
-        env:
-          GEM_HOST_OTP_CODE: ${{ inputs.rubygems_otp }}
       - name: Create a Release
         id: create-release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0


### PR DESCRIPTION
I just configured GitHub Actions as a [trusted publisher](https://guides.rubygems.org/trusted-publishing/) for the `ynab` gem on RubyGems.org, which means publishing no longer needs a manually pasted API key and OTP code every time we run the workflow. This updates `publish.yml` accordingly.

The workflow now requests a GitHub OIDC token (via the new `id-token: write` permission) and exchanges it for a short-lived RubyGems key using the official `rubygems/configure-rubygems-credentials` action, pinned to a commit SHA like our other actions. That replaces the step that wrote the pasted key into `~/.gem/credentials`, and since trusted publishing tokens bypass the OTP requirement, both the `rubygems_api_key` and `rubygems_otp` inputs are gone, along with the `action-hide-sensitive-inputs` step that existed only to mask them in the logs.

One thing to notice: adding an explicit `permissions` block replaces the default token permissions, so the block also includes `contents: write` (for the release creation step) and `issues: write` / `pull-requests: write` (for the step that comments on released PRs). Everything downstream (`rake publish`, the version bump, the GitHub release) is unchanged.

### Testing
This can only really be verified by running the publish workflow itself, so the next release will be the proof. The trusted publisher on RubyGems.org is registered against this repo with workflow filename `publish.yml` and no environment restriction, matching this configuration.