### PR TITLE
Drop unneeded `issues: write` permission from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      issues: write
-      pull-requests: write
+      pull-requests: write # comment on PRs included in the release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Follow-up to dbertram's [feedback on ynab-sdk-python#31](https://github.com/ynab/ynab-sdk-python/pull/31#discussion_r3515445870). While reviewing the Python publish workflow we confirmed that `issues: write` isn't needed for the "comment on released PRs" step: `issues.createComment` keys its permission off the target resource, so commenting on a PR is covered by `pull-requests: write` alone. We never comment on a real issue in this workflow.

This makes the same cleanup here in the Ruby SDK's publish workflow: drops `issues: write` and annotates `pull-requests: write` with why it's needed, matching ynab-sdk-python.